### PR TITLE
Fix: Stop printf format warnings and add more exception handlers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CFILES = $(shell find sys/src/ -name "*.c")
 CFLAGS = -fexceptions -std=gnu11 -ffreestanding -fno-stack-protector \
   -fno-pic -Werror=implicit -Werror=implicit-function-declaration -Werror=implicit-int \
-  -Werror=int-conversion -Wno-format \
+  -Werror=int-conversion \
   -Werror=incompatible-pointer-types -Werror=int-to-pointer-cast -Werror=return-type -Wunused \
   -mabi=sysv -mno-80387 -mno-mmx \
   -mno-3dnow -mno-sse -mno-sse2 -mno-red-zone -mcmodel=kernel

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 CFILES = $(shell find sys/src/ -name "*.c")
 CFLAGS = -fexceptions -std=gnu11 -ffreestanding -fno-stack-protector \
   -fno-pic -Werror=implicit -Werror=implicit-function-declaration -Werror=implicit-int \
-  -Werror=int-conversion \
+  -Werror=int-conversion -Wno-format \
   -Werror=incompatible-pointer-types -Werror=int-to-pointer-cast -Werror=return-type -Wunused \
   -mabi=sysv -mno-80387 -mno-mmx \
   -mno-3dnow -mno-sse -mno-sse2 -mno-red-zone -mcmodel=kernel
 
-CC = cross/bin/x86_64-elf-gcc
-LD = cross/bin/x86_64-elf-ld
+CC = x86_64-elf-gcc
+LD = x86_64-elf-ld
 
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ CFLAGS = -fexceptions -std=gnu11 -ffreestanding -fno-stack-protector \
   -mabi=sysv -mno-80387 -mno-mmx \
   -mno-3dnow -mno-sse -mno-sse2 -mno-red-zone -mcmodel=kernel
 
-CC = x86_64-elf-gcc
-LD = x86_64-elf-ld
+CC = cross/bin/x86_64-elf-gcc
+LD = cross/bin/x86_64-elf-ld
 
 
 .PHONY: all

--- a/sys/src/arch/x64/exceptions.c
+++ b/sys/src/arch/x64/exceptions.c
@@ -16,6 +16,11 @@ E_ISR(0x1) {
   INTR_END;
 }
 
+E_ISR(0x2) {
+  printk(PRINTK_PANIC "Non-Maskable Interrupt\n");
+  INTR_END;
+}
+
 E_ISR(0x3) {
   printk(PRINTK_PANIC "Breakpoint exception\n");
   INTR_END;
@@ -32,7 +37,22 @@ E_ISR(0x5) {
 }
 
 E_ISR(0x6) {
-  printk(PRINTK_PANIC "Undefined opcode\n");
+  printk(PRINTK_PANIC "Invalid opcode\n");
+  INTR_END;
+}
+
+E_ISR(0x7) {
+  printk(PRINTK_PANIC "Coprocessor not available\n");
+  INTR_END;
+}
+
+E_ISR(0x8) {
+  printk(PRINTK_PANIC "Double fault\n");
+  INTR_END;
+}
+
+E_ISR(0x9) {
+  printk(PRINTK_PANIC "Coprocessor segment overrun\n");
   INTR_END;
 }
 
@@ -61,16 +81,32 @@ E_ISR(0xE) {
   INTR_END;
 }
 
+E_ISR(0xF) {
+  printk(PRINTK_PANIC "Reserved exception\n");
+  INTR_END;
+}
+
+E_ISR(0x10) {
+  printk(PRINTK_PANIC "Coprocessor error\n");
+  INTR_END;
+}
+
 void init_exceptions(void) {
   register_exception_handler(0x0, REF_E_ISR(0x0));
   register_exception_handler(0x1, REF_E_ISR(0x1));
+  register_exception_handler(0x2, REF_E_ISR(0x2));
   register_exception_handler(0x3, REF_E_ISR(0x3));
   register_exception_handler(0x4, REF_E_ISR(0x4));
   register_exception_handler(0x5, REF_E_ISR(0x5));
   register_exception_handler(0x6, REF_E_ISR(0x6));
+  register_exception_handler(0x7, REF_E_ISR(0x7));
+  register_exception_handler(0x8, REF_E_ISR(0x8));
+  register_exception_handler(0x9, REF_E_ISR(0x9));
   register_exception_handler(0xA, REF_E_ISR(0xA));
   register_exception_handler(0xB, REF_E_ISR(0xB));
   register_exception_handler(0xC, REF_E_ISR(0xC));
   register_exception_handler(0xD, REF_E_ISR(0xD));
   register_exception_handler(0xE, REF_E_ISR(0xE));
+  register_exception_handler(0xF, REF_E_ISR(0xF));
+  register_exception_handler(0x10, REF_E_ISR(0x10));
 }


### PR DESCRIPTION
GCC complains that our printf function doesn't use the same formatting as glibc's. Also added more exception messages.