### PR TITLE
Update the actions file, to suppress node12 warn

### DIFF
--- a/.github/workflows/mkimg.yml
+++ b/.github/workflows/mkimg.yml
@@ -9,7 +9,7 @@ jobs:
    job:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build
         run: |
@@ -22,7 +22,7 @@ jobs:
           make toolchain
           make
       - name: Uploading ISO as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Qnixx
           path: Qnixx.iso


### PR DESCRIPTION
This update checkout and upload to v3, so the bothersome warning goes away.
